### PR TITLE
Fix pokedex link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ You can make and test changes simply by opening `testclient.html`.
 License
 ------------------------------------------------------------------------
 
-This dex is distributed under the terms of the [AGPLv3][4].
+This dex is distributed under the terms of the [AGPLv3][5].
 
-  [4]: http://www.gnu.org/licenses/agpl-3.0.html
+  [5]: http://www.gnu.org/licenses/agpl-3.0.html
 
 WARNING: This is NOT the same license as Pokémon Showdown's server.


### PR DESCRIPTION
The license URL overrode the pokedex URL since they were the same number.
