### PR TITLE
Add a 'Battle Rules' article for EBC

### DIFF
--- a/articles/battlerules.md
+++ b/articles/battlerules.md
@@ -1,4 +1,4 @@
-# Rules
+# Battle Rules
 
 ## Endless Battle Clause
 

--- a/articles/rules.md
+++ b/articles/rules.md
@@ -1,0 +1,8 @@
+# Rules
+
+## Endless Battle Clause
+
+- Any Pokémon hit by a foe’s [[Heal Pulse]] or [[Floral Healing]] becomes stale.
+- Any Pokémon _using_ (consuming) an _acquired Leppa Berry_ (defined as a [[Leppa Berry]] which the Pokemon did not start the battle with, for example, one obtained via [[Fling]], [[Trick]], [[Harvest]], [[Recycle]], [[Bug Bite]], [[Pluck]], [[Pickup]] etc) becomes stale.
+- If all Pokémon on the field are stale and at least one team does not have the option of switching to a non-stale Pokémon, with at least one side's Pokémon's staleness having been inflicted by a Pokémon of the opposing side, the game ends. If only one side started the battle with the _rudimentary means to perform Leppa Berry-cycling_ (defined to be a team containing a Pokémon holding a [[Leppa Berry]] and a Pokémon with [[Recycle]] or [[Harvest]] or [[Pickup]], it loses, otherwise the battle ends in a tie.
+- The maximum length of any battle is 1000 turns, after which the game ends in a tie.


### PR DESCRIPTION
Can't verify with testing. FWIW, the following assumptions should probably be fixed with respect to the build.

- the assumption `Zarel/Pokemon-Showdown-Client` exists at `../play.pokemonshowdown.com`
- there is no `package.json` listing a dependency on the required `showdown` package
- the build dies if `.articles-cached/` doesn't exist instead of making the directory
- turning line breaks used to wrap long lines into hard `<br />` tags is pretty obnoxious

Even after getting the build to work, I couldn't figure out how to get 'Rules' article to load in the test client (I could get 'Critical Hit' to load though), but I verified the it look sane by manually opening the built file:

![test](https://user-images.githubusercontent.com/117249/57317167-5e486780-70ac-11e9-932c-d36224a6d619.png)

I will comment with the link in `config/ruleset.js` on the server once this lands.