### PR TITLE
Show more type effectiveness info

### DIFF
--- a/js/pokedex-pokemon.js
+++ b/js/pokedex-pokemon.js
@@ -76,7 +76,10 @@ var PokedexPokemonPanel = PokedexResultPanel.extend({
 		buf += '</dl>';
 
 		buf += '<dl>';
-		buf += '<dt style="clear:left">Base stats:</dt><dd><table class="stats">';
+		buf += '<dt style="clear:left">Defensive effectiveness:</dt>';
+		buf += '<dd>'+PokedexTypePanel.prototype.renderDefensiveEffectiveness(pokemon.types)+'</dd>';
+
+		buf += '<dt>Base stats:</dt><dd><table class="stats">';
 
 		var StatTitles = {
 			hp: "HP",

--- a/theme/pokedex.css
+++ b/theme/pokedex.css
@@ -409,6 +409,40 @@ a.subtle:hover {
 .type.special{background-color:#ADB1BD;background:linear-gradient(#ADB1BD,#7D828D);border-color:#A1A5AD;color:#E0E2E4;}
 .type.status{background-color:#CBC9CB;background:linear-gradient(#CBC9CB,#AAA6AA);border-color:#A99890;color:#F5F4F5;}
 
+.typeeff {
+	width: 100%;
+	table-layout: fixed;
+	border-collapse: collapse;
+	font-size: 9pt;
+}
+.typeeff tr {
+	line-height: 1.25;
+}
+.typeeff th {
+	font-size: 7pt;
+	font-weight: bold;
+}
+.typeeff td {
+	padding: 2px 6px 0;
+	border: 1px solid #AAAAAA;
+}
+.typeeff.defense td.eff4, .typeeff.offense td.eff0 {
+	background-color: rgba(255,128,128,.2);
+}
+.typeeff.defense td.eff3, .typeeff.offense td.eff1 {
+	background-color: rgba(255,128,128,.1);
+}
+.typeeff.defense td.eff1, .typeeff.offense td.eff3 {
+	background-color: rgba(128,255,128,.1);
+}
+.typeeff.defense td.eff0, .typeeff.offense td.eff4 {
+	background-color: rgba(128,255,128,.2);
+}
+.typeeff td.immune {
+	padding-bottom: 2px;
+	background-color: rgba(128,128,128,.1);
+}
+
 .pokemonicon, .picon {
 	display: inline-block;
 	vertical-align: -6px;


### PR DESCRIPTION
This PR:
* Adds offensive type effectiveness to type pages
* Reorganizes type effectiveness information into tables like this: ![steel type effectiveness tables](https://github.com/user-attachments/assets/c510683f-f290-417e-a7f0-c15f6255dd10)
* Adds defensive type effectiveness to Pokémon pages: ![Tinkaton defensive type effectiveness table](https://github.com/user-attachments/assets/80ed8e9e-c716-4f43-8201-bc92b106d5d1)

I will say that I don't very much like the use of `PokedexTypePanel.prototype` here:
https://github.com/phantamanta44/Pokemon-Showdown-Dex/blob/52dfeb284c849df399b4871de85e552401c6e713/js/pokedex-pokemon.js#L80
However, I couldn't find any existing cases of rendering code shared between different panel types (aside from external rendering functions from the Showdown libs), so I wasn't sure how I should structure it.

Closes #10 