### PR TITLE
Show more type effectiveness info v2

### DIFF
--- a/js/pokedex-pokemon.js
+++ b/js/pokedex-pokemon.js
@@ -76,7 +76,10 @@ var PokedexPokemonPanel = PokedexResultPanel.extend({
 		buf += '</dl>';
 
 		buf += '<dl>';
-		buf += '<dt style="clear:left">Base stats:</dt><dd><table class="stats">';
+		buf += '<dt style="clear:left">Defensive effectiveness:</dt>';
+		buf += '<dd>'+PokedexTypePanel.prototype.renderDefensiveEffectiveness(pokemon.types)+'</dd>';
+
+		buf += '<dt>Base stats:</dt><dd><table class="stats">';
 
 		var StatTitles = {
 			hp: "HP",

--- a/theme/pokedex.css
+++ b/theme/pokedex.css
@@ -409,6 +409,40 @@ a.subtle:hover {
 .type.special{background-color:#ADB1BD;background:linear-gradient(#ADB1BD,#7D828D);border-color:#A1A5AD;color:#E0E2E4;}
 .type.status{background-color:#CBC9CB;background:linear-gradient(#CBC9CB,#AAA6AA);border-color:#A99890;color:#F5F4F5;}
 
+.typeeff {
+	width: 100%;
+	table-layout: fixed;
+	border-collapse: collapse;
+	font-size: 9pt;
+}
+.typeeff tr {
+	line-height: 1.25;
+}
+.typeeff th {
+	font-size: 7pt;
+	font-weight: bold;
+}
+.typeeff td {
+	padding: 2px 6px 0;
+	border: 1px solid #AAAAAA;
+}
+.typeeff.defense td.eff4, .typeeff.offense td.eff0 {
+	background-color: rgba(255,128,128,.2);
+}
+.typeeff.defense td.eff3, .typeeff.offense td.eff1 {
+	background-color: rgba(255,128,128,.1);
+}
+.typeeff.defense td.eff1, .typeeff.offense td.eff3 {
+	background-color: rgba(128,255,128,.1);
+}
+.typeeff.defense td.eff0, .typeeff.offense td.eff4 {
+	background-color: rgba(128,255,128,.2);
+}
+.typeeff td.immune {
+	padding-bottom: 2px;
+	background-color: rgba(128,128,128,.1);
+}
+
 .pokemonicon, .picon {
 	display: inline-block;
 	vertical-align: -6px;


### PR DESCRIPTION
Hey @phantamanta44 and @Zarel I really like the addition in #33! Unfortunately I cannot push to that branch directly, so I added a commit here to implement Zarel's suggestion to make the display of the effectiveness section togglable, making it hidden by default.

Moreover, I added a couple more things:

- A note for ability-modified effectiveness in pokemon pages
- Deduplication of the immunity list entries in pokemon pages (e.g. Rhydon had duplicated "Sandstorm damage" immunity, or Revavroom had duplicated "PSN status" immunity)

Thanks everyone for the consideration - I hope we can get this landed, looks like a very nice and useful improvement!

Closes #10 

<img width="649" height="135" alt="image" src="https://github.com/user-attachments/assets/d4220668-8688-48ff-94cf-2619ae299fbc" />

<img width="649" height="175" alt="image" src="https://github.com/user-attachments/assets/fe02d05e-b0e5-45d3-90ae-0f45a426d963" />

<img width="649" height="139" alt="image" src="https://github.com/user-attachments/assets/c8df17c8-bd61-40d2-8208-cb4f9c4f46bd" />

<img width="649" height="213" alt="image" src="https://github.com/user-attachments/assets/52ada646-bc48-4a16-b9e9-18c1e4d304b2" />

<img width="649" height="193" alt="image" src="https://github.com/user-attachments/assets/eb936fcc-9e68-4ee0-b4d6-d2646772bd2c" />

<img width="649" height="272" alt="image" src="https://github.com/user-attachments/assets/4a624e37-d750-45f1-8198-427d1099aff2" />

<img width="649" height="273" alt="image" src="https://github.com/user-attachments/assets/cfefc59d-ebdd-401f-ad95-91b3c47f257c" />

<img width="649" height="319" alt="image" src="https://github.com/user-attachments/assets/ec49780c-fe23-4a13-9054-f4379398a813" />